### PR TITLE
KSSU-1389: Endrer errorJson til et map for deserialisering

### DIFF
--- a/src/main/kotlin/no/ks/svarut/klient/BaseKlient.kt
+++ b/src/main/kotlin/no/ks/svarut/klient/BaseKlient.kt
@@ -1,5 +1,6 @@
 package no.ks.svarut.klient
 
+import com.fasterxml.jackson.databind.DatabindException
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
@@ -60,8 +61,26 @@ abstract class BaseKlient(
     }
 
     fun ObjectMapper.bodyToException(body: String): Exception = try {
-        SvarUtKlientException(objectMapper.readValue(body))
+        SvarUtKlientException(body.toErrorMessage())
     } catch (e: Exception) {
-        RuntimeException("Uventet feil. Response body: $body")
+        RuntimeException("Uventet feil. Response body: $body", e)
     }
+
+    private fun String.toErrorMessage(): ErrorMessage =
+        try {
+            objectMapper.readValue(this)
+        } catch (_: DatabindException) {
+            ErrorMessage(
+                timestamp = null,
+                status = null,
+                error = null,
+                errorId = null,
+                path = null,
+                originalPath = null,
+                message = "Klarte ikke å parse feilmelding. Body: $this",
+                errorCode = null,
+                errorJson = null,
+            )
+        }
+
 }

--- a/src/main/kotlin/no/ks/svarut/klient/SvarUtKlientException.kt
+++ b/src/main/kotlin/no/ks/svarut/klient/SvarUtKlientException.kt
@@ -13,5 +13,5 @@ data class ErrorMessage(
     val originalPath: String?,
     val message: String?,
     val errorCode: String?,
-    val errorJson: String?
+    val errorJson: Map<String, String>?,
 )


### PR DESCRIPTION
Endrer `errorJson` til å være et map med strings. Åpent spørsmål om det kan være behov for at vi trenger et map som ikke bare er strings?